### PR TITLE
[contribution] changed "Download" to "Source Code"

### DIFF
--- a/web/content/en/contribution/Download.md
+++ b/web/content/en/contribution/Download.md
@@ -6,5 +6,5 @@ weight: 3
 
 ---
 
-All source code is available through our <a href="https://github.com/pymanga/pyMANGA/" target="_blank">GitHub repository</a>.  
+All source code is available via our <a href="https://github.com/pymanga/pyMANGA/" target="_blank">GitHub repository</a>.  
 If you are interested in contributing, we encourage you to clone the repository and create a pull request.  

--- a/web/content/en/contribution/Download.md
+++ b/web/content/en/contribution/Download.md
@@ -1,12 +1,10 @@
 
 ---
-title: Download
-linkTitle: Download
+title: Source Code
+linkTitle: Source Code
 weight: 3
 
 ---
 
-
-Please download the source code via GitHub.
-<a href="https://github.com/jbathmann/pyMANGA" target="_blank">GitHub repository</a>
-
+All source code is available through our <a href="https://github.com/pymanga/pyMANGA/" target="_blank">GitHub repository</a>.  
+If you are interested in contributing, we encourage you to clone the repository and create a pull request.  


### PR DESCRIPTION
Page title change is a suggestion since "Download" seemed outdated.
Other ideas I had include "Code Availability" or "Source Code Availability".