### PR TITLE
[toc] Contribution toc position

### DIFF
--- a/web/themes/docsy/layouts/contribution/list.html
+++ b/web/themes/docsy/layouts/contribution/list.html
@@ -5,8 +5,8 @@
 	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
             {{ partial "reading-time.html" . }}
         {{ end }}
-	{{ partial "section-index.html" . }}
 	{{ .Content }}
+	{{ partial "section-index.html" . }}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
 		<br />


### PR DESCRIPTION
Reverted changes to table of contents for the contribution/developer guide page to display the TOC below the short description. As proposed in #24.